### PR TITLE
Add HALT instruction support

### DIFF
--- a/src/components/avr/mcu/branches.rs
+++ b/src/components/avr/mcu/branches.rs
@@ -10,6 +10,11 @@ const Z_REG: u16 = 30;
 
 impl Mcu {
     pub fn instr_rjmp(&mut self, opcode: u16) -> u8 {
+        if opcode == 0xCFFF {
+            self.halted = true;
+            return 2;
+        }
+
         let k = opcode & 0x0FFF;
 
         if k.bit(11) {
@@ -171,6 +176,7 @@ impl Mcu {
     }
 
     pub fn execute_interrupt(&mut self, addr: u16) -> u8 {
+        self.halted = false;
         self.pc -= 1;
         self.push_pc();
         self.set_pc(addr as u32);

--- a/src/events.rs
+++ b/src/events.rs
@@ -161,4 +161,20 @@ impl EventQueue {
     pub fn set_multiplexer_flag(&mut self, pin: PinAddress, flag: bool) {
         self.multiplexing_table.set_flag(pin, flag)
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.internal_events.is_empty() && self.wire_events.is_empty()
+    }
+
+    pub fn skip_to_event(&mut self) {
+        let t1 = self.wire_events.peek().map(|(_, &Reverse(t))| t);
+        let t2 = self.internal_events.peek().map(|(_, &Reverse(t))| t);
+        let t = t1.min(t2);
+        if let Some(t) = t {
+            let ticks = self.clock.time_to_ticks(t) - self.clock.current_tick();
+            self.clock.advance(ticks);
+        } else {
+            self.clock.advance(1000);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,9 @@ fn main() {
     const SIMULATION_SECONDS: i64 = 10;
     const FREQ: i64 = 16_000_000;
     const CYCLES: i64 = SIMULATION_SECONDS * FREQ;
-    mcu.run_until_time(CYCLES);
+    let model_time = mcu.run_until_time(CYCLES);
     let simulation_time = start.elapsed();
-    let model_time = Duration::from_secs(SIMULATION_SECONDS as u64);
+    let model_time = Duration::from_micros((model_time as f64 / FREQ as f64 * 1e6) as u64);
     println!(
         "Model Time: {} ms, Simulation Time: {} ms, Speed: {:.2}%",
         model_time.as_millis(),

--- a/src/module.rs
+++ b/src/module.rs
@@ -32,6 +32,6 @@ pub trait WireableModule: Module {
 }
 
 pub trait ActiveModule: Module {
-    fn run_until_time(&mut self, t: Timestamp);
+    fn run_until_time(&mut self, t: Timestamp) -> Timestamp;
     fn module_store(&mut self) -> &mut PassiveModuleStore;
 }


### PR DESCRIPTION
Add support for simulation halting: after reaching a halt (infinite loop) instruction (opcode `0xCFFF`) the simulation will switch into a halted mode and skip until further events (without wasting CPU)